### PR TITLE
Update for Swift4

### DIFF
--- a/CollectionViewShelfLayout/CollectionViewShelfLayout.swift
+++ b/CollectionViewShelfLayout/CollectionViewShelfLayout.swift
@@ -110,7 +110,9 @@ open class CollectionViewShelfLayout: UICollectionViewLayout {
     if let headerView = headerView {
       headerViewLayoutAttributes = CollectionViewShelfLayoutHeaderFooterViewLayoutAttributes(forDecorationViewOfKind: ShelfElementKindCollectionHeader, with: IndexPath(index: 0))
       headerViewLayoutAttributes?.view = headerView
-      let headerViewSize = headerView.systemLayoutSizeFitting(CGSize(width: collectionViewWidth, height: 0.0), withHorizontalFittingPriority: .required, verticalFittingPriority: .fittingSizeLevel)
+      //let headerViewSize = headerView.systemLayoutSizeFitting(CGSize(width: collectionViewWidth, height: 0.0), withHorizontalFittingPriority: .required, verticalFittingPriority: .fittingSizeLevel)
+      let targetSize = CGSize(width: collectionViewWidth, height: 0.0)
+      let headerViewSize = headerView.systemLayoutSizeFitting(targetSize, withHorizontalFittingPriority: UILayoutPriorityRequired, verticalFittingPriority: UILayoutPriorityFittingSizeLevel)
       headerViewLayoutAttributes?.size = headerViewSize
       headerViewLayoutAttributes?.frame = CGRect(origin: CGPoint(x: collectionBounds.minX, y: currentY), size: headerViewSize)
       currentY += headerViewSize.height
@@ -206,7 +208,7 @@ open class CollectionViewShelfLayout: UICollectionViewLayout {
     if let footerView = footerView {
       footerViewLayoutAttributes = CollectionViewShelfLayoutHeaderFooterViewLayoutAttributes(forDecorationViewOfKind: ShelfElementKindCollectionFooter, with: IndexPath(index: 0))
       footerViewLayoutAttributes?.view = footerView
-      let footerViewSize = footerView.systemLayoutSizeFitting(CGSize(width: collectionViewWidth, height: 0.0), withHorizontalFittingPriority: .required, verticalFittingPriority: .fittingSizeLevel)
+      let footerViewSize = footerView.systemLayoutSizeFitting(CGSize(width: collectionViewWidth, height: 0.0), withHorizontalFittingPriority: UILayoutPriorityRequired, verticalFittingPriority: UILayoutPriorityFittingSizeLevel)
       footerViewLayoutAttributes?.size = footerViewSize
       footerViewLayoutAttributes?.frame = CGRect(origin: CGPoint(x: collectionBounds.minX, y: currentY), size: footerViewSize)
       currentY += footerViewSize.height


### PR DESCRIPTION
in func prepare(),
for HeaderView & FooterView's systemLayoutSizeFitting function,  (line 111 to 118 and 209 to 214)
1) HorizontalFittingPriority changed from UILayoutPriority.required to UILayoutPriorityRequired
2) VerticalFittingPriority changed from UILayoutPriority..fittingSizeLevel to UILayoutPriorityFittingSizeLevel